### PR TITLE
Extract more details for `mounts.json`

### DIFF
--- a/generate.js
+++ b/generate.js
@@ -185,13 +185,15 @@ function processMountNode(mountNode)
 {
 	var mount = {};
 	mount.id = attributeValue(mountNode, "id");
+	mount.attributeid = getValue(mountNode, "AttributeId");
 	mount.name = S["Mount/Name/" + mount.id];
 
 	if(!mount.name)
 		return undefined;
 	
 	mount.description = S["Mount/Info/" + mount.id];
-	mount.franchise = getValue(mountNode, "Universe", "Starcraft");
+	mount.category = getValue(mountNode, "MountCategory");
+	mount.franchise = getValue(mountNode, "Universe", "Custom");
 
 	if(!!(+getValue(mountNode, "Flags[@index='IsVariation']", 0)))
 		return undefined;


### PR DESCRIPTION
Correct and Extract additional details for mounts.
- Added `AttributeId` so replay processors can reference.
- Added `MountCategory` for no good reason other than my OCD.
- Corrected Universe default to `Custom` rather than `StarCraft`.  The rewards (Void Speeder, MechoSpider, Vulture, etc) do NOT have Universes and we cannot assume they belong to any Universe (`StarCraft`, `Heroes`, or otherwise).

Closes #3 
