### PR TITLE
update build process to not trigger git v1.7.0+ 'feature'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+build/
 heroesjson.sublime-project
 heroesjson.sublime-workspace
 node_modules

--- a/build.sh
+++ b/build.sh
@@ -4,14 +4,13 @@ echo "Geting CASCExtractor..."
 git submodule update --init --recursive
 
 echo "Building CASCExtractor..."
-cd CASCExtractor
 mkdir build
 cd build
-cmake ..
+cmake ../CASCExtractor
 make
 
 echo "Installing NPM modules..."
-cd ../..
+cd ../
 npm install
 
 echo "Linking shared JS..."

--- a/generate.js
+++ b/generate.js
@@ -28,7 +28,7 @@ if(!fs.existsSync(HOTS_DATA_PATH))
 	process.exit(1);
 }
 
-var CASCEXTRATOR_PATH = path.join(__dirname, "CASCExtractor", "build", "bin", "CASCExtractor");
+var CASCEXTRATOR_PATH = path.join(__dirname, "build", "bin", "CASCExtractor");
 
 var OUT_PATH = path.join(__dirname, "out");
 


### PR DESCRIPTION
Versions 1.7.0 and later of `git` contain an annoying change in the behavior of `git submodule`.
Submodules are now regarded as dirty if they have any modified files or untracked files, whereas previously it would only be the case if HEAD in the submodule pointed to the wrong commit.

When building and creating the `CASCExtractor/build/` directory, it flags the repo as dirty.

This change moves the build directory under `./` and updates the commands as such.
