### PR TITLE
Permit variation mounts in mounts.json

### DIFF
--- a/generate.js
+++ b/generate.js
@@ -170,7 +170,7 @@ tiptoe(
 
 		base.info("\nProcessing mounts...");
 		var mounts = Object.values(NODE_MAPS["Mount"]).map(function(mountNode) { return processMountNode(mountNode); }).filterEmpty();
-		
+
 		base.info("\nValidating %d mounts...", mounts.length);
 		mounts.forEach(validateMount);
 		mounts.sort(function(a, b) { return (a.name.startsWith("The ") ? a.name.substring(4) : a.name).localeCompare((b.name.startsWith("The ") ? b.name.substring(4) : b.name)); });
@@ -201,10 +201,18 @@ function processMountNode(mountNode)
 	mount.attributeid = getValue(mountNode, "AttributeId");
 	mount.name = S["Mount/Name/" + mount.id];
 
-	if(!mount.name || !!(+getValue(mountNode, "Flags[@index='IsVariation']", 0)))
+	if(!mount.name) {
 		return undefined;
+	}
+
+	mount.variation = (+getValue(mountNode, "Flags[@index='IsVariation']", 0) === 1) ? true : false;
 
 	mount.description = S["Mount/Info/" + mount.id];
+	// Some mounts share info with their model parent
+	if(!mount.description && S["Mount/Info/" + getValue(mountNode, "Model")]) {
+		mount.description = S["Mount/Info/" + getValue(mountNode, "Model")];
+	}
+
 	mount.franchise = getValue(mountNode, "Universe");
 	mount.releaseDate = processReleaseDate(mountNode.get("ReleaseDate"));
 	mount.productid = getValue(mountNode, "ProductId");

--- a/shared/C.js
+++ b/shared/C.js
@@ -311,15 +311,15 @@ exports.MOUNT_JSON_SCHEMA =
 {
 	name : "mount",
 	type : "object",
-	additionalProperties : false,
+	additionalProperties : true,
 	properties           :
 	{
 		id          : { type : "string", minLength : 1 },
 		attributeid : { type : "string", minLength : 1 },
 		name        : { type : "string", minLength : 1 },
-		description : { type : "string", minLength : 1 },
 		franchise   : { type : "string", minLength : 1 },
 		releaseDate : { type : "string", pattern : "2[0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]" },
+		variation   : { type : "boolean" },
 		productid   : { type : "integer" },
 		category    : { type : "string", minLength : 1 },
 	}


### PR DESCRIPTION
First, I changed the schema to allow `variation` and removed `description`
as a required field (changing `additionalProperties` to `true` as a result).

Secondly, every mount has a `variation`, set to `true` or `false` depending
on if it is the base skin or not.  For mounts that have a `Model` name that
matches an entry in `GameStrings.txt`, I use that for the `description`.

There are three (3) different schemas of variations for mounts within the
XML (thanks blizz!).  Two (2) of them reference an original base model and
the third reference a common model. Only the third method populates all the
fields as we cannot reference other entries within the `.map()` loop.  To
completely fill these, a second iteration over the mounts will be needed.
